### PR TITLE
Chore: ENV-3225 Secrets usage in velocity blueprints

### DIFF
--- a/getting-started/aws/sample-helm/templates/db-credentials.yaml
+++ b/getting-started/aws/sample-helm/templates/db-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-credentials
+type: Opaque
+data:
+  DB_USER: {{ .Values.db_user | b64enc }}
+  DB_PASSWORD: {{ .Values.db_pass | b64enc }}

--- a/getting-started/aws/sample-helm/templates/explorer.yaml
+++ b/getting-started/aws/sample-helm/templates/explorer.yaml
@@ -27,6 +27,10 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          envFrom:
+            - secretRef:
+                name: db-credentials
+                optional: false
           env:
             - name: AWS_REGION
               value: {{ .Values.region }}
@@ -36,10 +40,6 @@ spec:
               value: {{ .Values.db_host | toJson }}
             - name: DB_PORT
               value: {{ .Values.db_port | toJson }}
-            - name: DB_USER
-              value: {{ .Values.db_user | toJson }}
-            - name: DB_PASS
-              value: {{ .Values.db_pass | toJson }}
             - name: QUEUE_NAME
               value: {{ .Values.queue_name | toJson }}
             - name: DYNAMODB_TABLE_NAME

--- a/getting-started/aws/sample-k8s/db-credentials.yaml
+++ b/getting-started/aws/sample-k8s/db-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-credentials
+type: Opaque
+data:
+  DB_USER: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS51c2VyfQ== # "{velocity.v1:mysql.exposures(port=mysql).user}" base64 encoded
+  DB_PASSWORD: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS5wYXNzd29yZH0= # "{velocity.v1:mysql.exposures(port=mysql).password}" base64 encoded

--- a/getting-started/aws/sample-k8s/explorer.yaml
+++ b/getting-started/aws/sample-k8s/explorer.yaml
@@ -41,6 +41,10 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          envFrom:
+            - secretRef:
+                name: db-credentials
+                optional: false
           env:
             - name: AWS_REGION
               value: eu-central-1
@@ -50,10 +54,6 @@ spec:
               value: "{velocity.v1:psql.exposures(port=tcp).host}"
             - name: DB_PORT
               value: "{velocity.v1:psql.exposures(port=tcp).port}"
-            - name: DB_USER
-              value: "{velocity.v1:psql.exposures(port=tcp).user}"
-            - name: DB_PASS
-              value: "{velocity.v1:psql.exposures(port=tcp).password}"
             - name: QUEUE_NAME
               value: "{velocity.v1.envName}-my-queue"
             - name: DYNAMODB_TABLE_NAME

--- a/getting-started/gcp/sample-helm/templates/db-credentials.yaml
+++ b/getting-started/gcp/sample-helm/templates/db-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-credentials
+type: Opaque
+data:
+  DB_USER: {{ .Values.db_user | b64enc }}
+  DB_PASSWORD: {{ .Values.db_pass | b64enc }}

--- a/getting-started/gcp/sample-helm/templates/explorer.yaml
+++ b/getting-started/gcp/sample-helm/templates/explorer.yaml
@@ -28,6 +28,10 @@ spec:
           image: {{ .Values.image }}
           ports:
             - containerPort: 80
+          envFrom:
+            - secretRef:
+                name: db-credentials
+                optional: false
           env:
             - name: PUBSUB_TOPIC
               value: {{ .Values.pubsub_topic_name | toJson  }}

--- a/getting-started/gcp/sample-k8s/db-credentials.yaml
+++ b/getting-started/gcp/sample-k8s/db-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-credentials
+type: Opaque
+data:
+  DB_USER: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS51c2VyfQ== # base64 of "{velocity.v1:mysql.exposures(port=mysql).user}"
+  DB_PASSWORD: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS5wYXNzd29yZH0= # base64 of "{velocity.v1:mysql.exposures(port=mysql).password}"

--- a/getting-started/gcp/sample-k8s/db-credentials.yaml
+++ b/getting-started/gcp/sample-k8s/db-credentials.yaml
@@ -4,5 +4,5 @@ metadata:
   name: db-credentials
 type: Opaque
 data:
-  DB_USER: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS51c2VyfQ== # base64 of "{velocity.v1:mysql.exposures(port=mysql).user}"
-  DB_PASSWORD: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS5wYXNzd29yZH0= # base64 of "{velocity.v1:mysql.exposures(port=mysql).password}"
+  DB_USER: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS51c2VyfQ== # "{velocity.v1:mysql.exposures(port=mysql).user}" base64 encoded
+  DB_PASSWORD: e3ZlbG9jaXR5LnYxOm15c3FsLmV4cG9zdXJlcyhwb3J0PW15c3FsKS5wYXNzd29yZH0= # "{velocity.v1:mysql.exposures(port=mysql).password}" base64 encoded

--- a/getting-started/gcp/sample-k8s/explorer.yaml
+++ b/getting-started/gcp/sample-k8s/explorer.yaml
@@ -28,6 +28,10 @@ spec:
           image: gcr.io/velocity-playground/gcp-explorer
           ports:
             - containerPort: 80
+          envFrom:
+            - secretRef:
+                name: db-credentials
+                optional: false
           env:
             - name: PUBSUB_TOPIC
               value: "{velocity.v1.envName}-topic"


### PR DESCRIPTION
This PR adds a usage example of secrets in velocity blueprints.

* GCP Helm
* GCP raw kubernetes
* AWS Helm 
* AWS raw kubernetes
