### PR TITLE
chore(ENV-3432): Removed aws access-related variables to use injected credentials

### DIFF
--- a/getting-started/aws/sample-helm/README.md
+++ b/getting-started/aws/sample-helm/README.md
@@ -40,7 +40,6 @@ The resulting `prod.yaml` file reflects the resulting artifacts of the helm char
 ### HOWTO - Dry run for Velocity Environment
 
 To dry run the helm chart for velocity environments, follow these instructions:
-* Modify `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` in `values-velocity.yaml` to reflect your AWS credentials for the AWS account you are working on.
 * run the following command:
    ```shell
    helm template --set provision_resources=true --values values-velocity.yaml . > velocity.yaml

--- a/getting-started/aws/sample-helm/templates/explorer.yaml
+++ b/getting-started/aws/sample-helm/templates/explorer.yaml
@@ -44,12 +44,6 @@ spec:
               value: {{ .Values.queue_name | toJson }}
             - name: DYNAMODB_TABLE_NAME
               value: {{ .Values.table_name | toJson }}
-            - name: AWS_ACCESS_KEY_ID
-              value: {{ .Values.aws_access_key_id }}
-            - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.aws_secret_access_key }}
-            - name: AWS_SESSION_TOKEN
-              value: {{ .Values.aws_session_token }}
 ---
 apiVersion: v1
 kind: Service

--- a/getting-started/aws/sample-helm/values-velocity.yaml
+++ b/getting-started/aws/sample-helm/values-velocity.yaml
@@ -1,13 +1,13 @@
 # {velocity.v1.envName} will be translated to unique ID per environment
 
 # bucket_name is prefixed with a random string and the environment name. This is because buckets are globally unique, so this allows us to have a bucket per environment without collisions.
-bucket_name: '{velocity.v1.generate:random([a-z]{1,64})}-{velocity.v1.envName}-my-bucket'
+bucket_name: 'velocity-{velocity.v1.generate:random([a-z]{1,64})}-{velocity.v1.envName}-my-bucket'
 
 # queue_name is prefixed with the environment name. This is because a queue name is unique per AWS account, so this allows us to have a queue per environment without collisions.
-queue_name: '{velocity.v1.envName}-my-queue'
+queue_name: 'velocity-{velocity.v1.envName}-my-queue'
 
 # table_name is prefixed with the environment name. This is because a table name is unique per AWS account, so this allows us to have a queue per environment without collisions.
-table_name: '{velocity.v1.envName}-my-table'
+table_name: 'velocity-{velocity.v1.envName}-my-table'
 
 # db_X values will be dynamically fetched from the `psql` service
 db_user: '{velocity.v1:psql.exposures(port=tcp).user}'
@@ -17,9 +17,5 @@ db_port: '{velocity.v1:psql.exposures(port=tcp).port}'
 
 image: gcr.io/velocity-playground/aws-explorer
 region: 'eu-central-1'
-
-aws_access_key_id: 'aws_access_key_id'
-aws_secret_access_key: 'aws_secret_access_key'
-aws_session_token: 'aws_session_token'
 
 provision_resources: true

--- a/getting-started/aws/sample-helm/values-velocity.yaml
+++ b/getting-started/aws/sample-helm/values-velocity.yaml
@@ -1,13 +1,13 @@
 # {velocity.v1.envName} will be translated to unique ID per environment
 
 # bucket_name is prefixed with a random string and the environment name. This is because buckets are globally unique, so this allows us to have a bucket per environment without collisions.
-bucket_name: 'velocity-{velocity.v1.generate:random([a-z]{1,64})}-{velocity.v1.envName}-my-bucket'
+bucket_name: '{velocity.v1.generate:random([a-z]{1,64})}-{velocity.v1.envName}-my-bucket'
 
 # queue_name is prefixed with the environment name. This is because a queue name is unique per AWS account, so this allows us to have a queue per environment without collisions.
-queue_name: 'velocity-{velocity.v1.envName}-my-queue'
+queue_name: '{velocity.v1.envName}-my-queue'
 
 # table_name is prefixed with the environment name. This is because a table name is unique per AWS account, so this allows us to have a queue per environment without collisions.
-table_name: 'velocity-{velocity.v1.envName}-my-table'
+table_name: '{velocity.v1.envName}-my-table'
 
 # db_X values will be dynamically fetched from the `psql` service
 db_user: '{velocity.v1:psql.exposures(port=tcp).user}'

--- a/getting-started/aws/sample-k8s/explorer.yaml
+++ b/getting-started/aws/sample-k8s/explorer.yaml
@@ -58,10 +58,4 @@ spec:
               value: "{velocity.v1.envName}-my-queue"
             - name: DYNAMODB_TABLE_NAME
               value: "{velocity.v1.envName}-my-table"
-            - name: AWS_ACCESS_KEY_ID
-              value: 'aws-access-key-id'
-            - name: AWS_SECRET_ACCESS_KEY
-              value: 'aws-secret-access-key'
-            - name: AWS_SESSION_TOKEN
-              value: 'aws-session-token'
 ---


### PR DESCRIPTION
## Description
This PR addresses ENV-3432

Currently, after 'injected credentials feature' had been deployed, the use of straight-forward access keys is redundant and even problematic.
Therefore, those access key variables had been removed in this activity.
