### PR TITLE
Add env-sync-python example

### DIFF
--- a/examples/env-sync-python/k8s/.helmignore
+++ b/examples/env-sync-python/k8s/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/examples/env-sync-python/k8s/Chart.yaml
+++ b/examples/env-sync-python/k8s/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: async-db-worker
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/examples/env-sync-python/k8s/Chart.yaml
+++ b/examples/env-sync-python/k8s/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: async-db-worker
+name: env-sync-example-python
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0

--- a/examples/env-sync-python/k8s/templates/web_api.yml
+++ b/examples/env-sync-python/k8s/templates/web_api.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    velocity.tech.v1/id: web-api
+  name: web-api
+  labels:
+    app: web-api
+spec:
+  selector:
+    matchLabels:
+      api: web-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: web-api
+        api: web-api
+    spec:
+      containers:
+        - name: web-api
+          image: jdvincent/env-sync-python:latest
+          env:
+          ports:
+            - name: web-api
+              containerPort: 8000
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-api
+spec:
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: web-api
+  selector:
+    app: web-api
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-api
+spec:
+  rules:
+    - host: {{ .Values.ingress_host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-api
+                port:
+                  number: 8000

--- a/examples/env-sync-python/k8s/velocity-values.yml
+++ b/examples/env-sync-python/k8s/velocity-values.yml
@@ -1,0 +1,1 @@
+ingress_host: "api-{velocity.v1.domainSuffix}"

--- a/examples/env-sync-python/src/web_api/Dockerfile
+++ b/examples/env-sync-python/src/web_api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-alpine
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY main.py .
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/examples/env-sync-python/src/web_api/main.py
+++ b/examples/env-sync-python/src/web_api/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from fastapi.responses import  HTMLResponse
+
+app = FastAPI()
+
+@app.get('/')
+async def index():
+    return HTMLResponse("<h1> Velocity Env Sync Example </h1>")
+
+
+    

--- a/examples/env-sync-python/src/web_api/main.py
+++ b/examples/env-sync-python/src/web_api/main.py
@@ -6,6 +6,3 @@ app = FastAPI()
 @app.get('/')
 async def index():
     return HTMLResponse("<h1> Velocity Env Sync Example </h1>")
-
-
-    

--- a/examples/env-sync-python/src/web_api/requirements.txt
+++ b/examples/env-sync-python/src/web_api/requirements.txt
@@ -1,0 +1,12 @@
+anyio==3.6.2
+click==8.1.3
+fastapi==0.88.0
+h11==0.14.0
+idna==3.4
+pydantic==1.10.2
+python-multipart==0.0.5
+six==1.16.0
+sniffio==1.3.0
+starlette==0.22.0
+typing_extensions==4.4.0
+uvicorn==0.20.0


### PR DESCRIPTION
Add example project to be used with the "Env Sync (Python)" tutorial in the Velocity docs. 